### PR TITLE
[PKG-1847] pynndescent 0.5.10

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,6 @@ test:
   imports:
     - pynndescent
   requires:
-    - python
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ about:
   home: https://github.com/lmcinnes/pynndescent
   license: BSD-2-Clause
   license_family: BSD
-  license_file: {{ environ["RECIPE_DIR"] }}/LICENSE
+  license_file: LICENSE
   summary: Simple fast approximate nearest neighbor search
   description: |
     A Python nearest neighbor descent for approximate nearest neighbors. 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   # numba and llvmlite aren't available on s390x
-  skip: true  # [py<36]
+  skip: true  # [py<36 or s390x]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - python
     - importlib-metadata >=4.8.1  # [py<38]
     - joblib >=0.11
-    - llvmlite >=0.30
+    - llvmlite >=0.34
     - numba >=0.51.2
     - numpy >=1.17
     - scikit-learn >=0.18

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pynndescent" %}
-{% set version = "0.5.4" %}
+{% set version = "0.5.10" %}
 
 package:
   name: {{ name|lower }}
@@ -7,44 +7,44 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 221124cbad8e3cf3ed421a4089d80ac5a29d3215e76cb49effc1df887533d2a8
+  sha256: 5d5dc683c03ef55fe3ddf693859720ca18f85c6e6e5bb0b4f14870278d5288ad
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<36]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python >=3.6
-    - setuptools
+    - python
     - pip
+    - setuptools
     - wheel
   run:
-    - python >=3.6
-    - numpy >=1.17
-    - numba >=0.51.2
+    - python
+    - importlib-metadata >=4.8.1  # [py<38]
+    - joblib >=0.11
     - llvmlite >=0.30
+    - numba >=0.51.2
+    - numpy >=1.17
     - scikit-learn >=0.18
     - scipy >=1.0
-    - joblib >=0.11
 
 test:
-  requires:
-    - python
-    - setuptools
-  commands:
-    - python -c "import pkg_resources; pkg_resources.require('pynndescent')"
   imports:
     - pynndescent
+  requires:
+    - python
+    - pip
+  commands:
+    - pip check
 
 about:
-  home: http://github.com/lmcinnes/pynndescent
+  home: https://github.com/lmcinnes/pynndescent
   license: BSD-2-Clause
   license_family: BSD
   license_file: {{ environ["RECIPE_DIR"] }}/LICENSE
   summary: Simple fast approximate nearest neighbor search
-
   description: |
     A Python nearest neighbor descent for approximate nearest neighbors. 
     This is a relatively straightforward python implementation of 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  # numba and llvmlite aren't available on s390x
   skip: true  # [py<36]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   # numba and llvmlite aren't available on s390x
-  skip: true  # [py<36 or s390x]
+  skip: true  # [py<37 or s390x]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:


### PR DESCRIPTION
Changelog: https://github.com/lmcinnes/pynndescent/releases
License: https://github.com/lmcinnes/pynndescent/blob/0.5.10/LICENSE
Requirements:
- https://github.com/lmcinnes/pynndescent/blob/0.5.10/requirements.txt
- https://github.com/lmcinnes/pynndescent/blob/0.5.10/setup.py

Actions:
1. Remove `noarch`
2. Skip `py<36` and `s390x` (because `numba` and `llvmlite` aren't available)
3. Add `--no-deps --no-build-isolation` to `script`
4. Add `importlib-metadata >=4.8.1  # [py<38]` to `run` and that's why `setuptools` and the command `python -c "import pkg_resources; pkg_resources.require('pynndescent')"` removed from `test`
5. Add `pip check`
6. Fix `home` url