### PR TITLE
PKG-8916: pynndescent 0.5.4 (rebuild - scikit-learn 1.7.0 compatibility)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,10 @@ source:
   sha256: 221124cbad8e3cf3ed421a4089d80ac5a29d3215e76cb49effc1df887533d2a8
 
 build:
-  number: 0
+  number: 1
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True  # [py<36]
 
 requirements:
   host:
@@ -22,7 +23,8 @@ requirements:
     - wheel
   run:
     - python >=3.6
-    - numpy >=1.17
+    # # AttributeError: `np.infty` was removed in the NumPy 2.0 release. Use `np.inf` instead.
+    - numpy >=1.17,<2
     - numba >=0.51.2
     - llvmlite >=0.30
     - scikit-learn >=0.18
@@ -51,7 +53,7 @@ about:
     Nearest Neighbor Descent for k-neighbor-graph construction and 
     approximate nearest neighbor search.
   dev_url: https://github.com/lmcinnes/pynndescent
-  doc_url: https://pynndescent.readthedocs.io/en/latest/
+  doc_url: https://pynndescent.readthedocs.io
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,21 +32,19 @@ requirements:
     - joblib >=0.11
 
 test:
-  requires:
-    - python
-    - setuptools
-  commands:
-    - python -c "import pkg_resources; pkg_resources.require('pynndescent')"
   imports:
     - pynndescent
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
-  home: http://github.com/lmcinnes/pynndescent
+  home: https://github.com/lmcinnes/pynndescent
   license: BSD-2-Clause
   license_family: BSD
   license_file: {{ environ["RECIPE_DIR"] }}/LICENSE
   summary: Simple fast approximate nearest neighbor search
-
   description: |
     A Python nearest neighbor descent for approximate nearest neighbors. 
     This is a relatively straightforward python implementation of 


### PR DESCRIPTION
pynndescent 0.5.4

**Destination channel:** defaults

### Links

- [PKG-8916](https://anaconda.atlassian.net/browse/PKG-8916) 
- [Upstream repository](https://github.com/lmcinnes/pynndescent/tree/0.5.4)

### Explanation of changes:

- Fix the downstream in scikit-learn


[PKG-8916]: https://anaconda.atlassian.net/browse/PKG-8916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ